### PR TITLE
Update examples to match change in qtl2scan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2plot
-Version: 0.4-5
+Version: 0.4-6
 Date: 2016-03-11
 Title: Data Visualization for QTL Experiments
 Description: Functions to plot QTL analysis results and related
@@ -17,7 +17,7 @@ Suggests:
     testthat,
     roxygen2,
     qtl2geno (>= 0.4-5),
-    qtl2scan (>= 0.4-5)
+    qtl2scan (>= 0.4-9)
 License: GPL-3
 URL: http://kbroman.org/qtl2
 LazyData: true

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -3,8 +3,7 @@
 #' Plot estimated QTL effects along a chromosomes.
 #'
 #' @param x Estimated QTL effects ("coefficients") as obtained from
-#' \code{\link[qtl2scan]{scan1coef}} or
-#' \code{\link[qtl2scan]{scan1coef_lmm}}.
+#' \code{\link[qtl2scan]{scan1coef}}.
 #'
 #' @param columns Vector of columns to plot
 #'
@@ -53,7 +52,7 @@
 #'
 #' # calculate coefficients for chromosome 7
 #' library(qtl2scan)
-#' coef <- scan1coef(probs[,7], pheno, covar)
+#' coef <- scan1coef(probs[,7], pheno, addcovar=covar)
 #'
 #' # plot QTL effects
 #' plot(coef, columns=1:3, col=c("slateblue", "violetred", "green3"))

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -2,8 +2,7 @@
 #'
 #' Plot LOD curves for a genome scan
 #'
-#' @param x Output of \code{\link[qtl2scan]{scan1}} or
-#' \code{\link[qtl2scan]{scan1_lmm}}.
+#' @param x Output of \code{\link[qtl2scan]{scan1}}.
 #'
 #' @param lodcolumn LOD score column to plot (a numeric index, or a
 #' character string for a column name). Only one value allowed.
@@ -47,7 +46,7 @@
 #'
 #' # perform genome scan
 #' library(qtl2scan)
-#' out <- scan1(probs, pheno, covar, Xcovar)
+#' out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 #'
 #' # plot the results for selected chromosomes
 #' ylim <- c(0, maxlod(out)*1.02) # need to strip class to get overall max LOD

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -2,10 +2,9 @@
 #'
 #' Plot SNP associations, with possible expansion from distinct snps to all snps.
 #'
-#' @param scan1output Output of \code{\link[qtl2scan]{scan1}} or
-#' \code{\link[qtl2scan]{scan1_lmm}}. Should contain an attribute,
-#' \code{"snpinfo"}, as when \code{\link[qtl2scan]{scan1}} or
-#' \code{\link[qtl2scan]{scan1_lmm}} are run with SNP probabilities
+#' @param scan1output Output of \code{\link[qtl2scan]{scan1}}.  Should
+#' contain an attribute, \code{"snpinfo"}, as when
+#' \code{\link[qtl2scan]{scan1}} are run with SNP probabilities
 #' produced by \code{\link[qtl2scan]{genoprob_to_snpprob}}.
 #'
 #' @param show_all_snps If TRUE, expand to show all SNPs.

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -19,8 +19,7 @@ plot_coefCC(x, add = FALSE, gap = 25, ylim = NULL, bgcolor = "gray90",
 }
 \arguments{
 \item{x}{Estimated QTL effects ("coefficients") as obtained from
-\code{\link[qtl2scan]{scan1coef}} or
-\code{\link[qtl2scan]{scan1coef_lmm}}.}
+\code{\link[qtl2scan]{scan1coef}}.}
 
 \item{columns}{Vector of columns to plot}
 
@@ -68,7 +67,7 @@ names(covar) <- rownames(iron$covar)
 
 # calculate coefficients for chromosome 7
 library(qtl2scan)
-coef <- scan1coef(probs[,7], pheno, covar)
+coef <- scan1coef(probs[,7], pheno, addcovar=covar)
 
 # plot QTL effects
 plot(coef, columns=1:3, col=c("slateblue", "violetred", "green3"))

--- a/man/plot_scan1.Rd
+++ b/man/plot_scan1.Rd
@@ -12,8 +12,7 @@ plot_scan1(x, lodcolumn = 1, chr = NULL, add = FALSE, gap = 25,
   gap = 25, bgcolor = "gray90", altbgcolor = "gray85", ...)
 }
 \arguments{
-\item{x}{Output of \code{\link[qtl2scan]{scan1}} or
-\code{\link[qtl2scan]{scan1_lmm}}.}
+\item{x}{Output of \code{\link[qtl2scan]{scan1}}.}
 
 \item{lodcolumn}{LOD score column to plot (a numeric index, or a
 character string for a column name). Only one value allowed.}
@@ -56,7 +55,7 @@ Xcovar <- get_x_covar(iron)
 
 # perform genome scan
 library(qtl2scan)
-out <- scan1(probs, pheno, covar, Xcovar)
+out <- scan1(probs, pheno, addcovar=covar, Xcovar=Xcovar)
 
 # plot the results for selected chromosomes
 ylim <- c(0, maxlod(out)*1.02) # need to strip class to get overall max LOD

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -10,10 +10,9 @@ plot_snpasso(scan1output, show_all_snps = TRUE, drop.hilit = NA,
   altbgcolor = "gray85", ...)
 }
 \arguments{
-\item{scan1output}{Output of \code{\link[qtl2scan]{scan1}} or
-\code{\link[qtl2scan]{scan1_lmm}}. Should contain an attribute,
-\code{"snpinfo"}, as when \code{\link[qtl2scan]{scan1}} or
-\code{\link[qtl2scan]{scan1_lmm}} are run with SNP probabilities
+\item{scan1output}{Output of \code{\link[qtl2scan]{scan1}}.  Should
+contain an attribute, \code{"snpinfo"}, as when
+\code{\link[qtl2scan]{scan1}} are run with SNP probabilities
 produced by \code{\link[qtl2scan]{genoprob_to_snpprob}}.}
 
 \item{show_all_snps}{If TRUE, expand to show all SNPs.}


### PR DESCRIPTION
Had merged `scan1()` and `scan1_lmm()`, as well as `scan1coef()` and `scan1coef_lmm()` and so generally need to name the `addcovar` argument.
