### PR TITLE
plot_genes: put gene name next to rather than below rectangle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2plot
-Version: 0.4-12
-Date: 2016-09-09
+Version: 0.4-13
+Date: 2016-09-12
 Title: Data Visualization for QTL Experiments
 Description: Functions to plot QTL analysis results and related
     diagnostics.Part of R/qtl2, a reimplementation of the R/qtl

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -108,11 +108,11 @@ plot_genes <-
         }
 
         # horizontal padding
-        em_space <- strwidth("m", cex=text_cex)
+        space <- strwidth(' ', cex=text_cex)
 
         # figure out how to arrange genes vertically
         #   + number of rows of genes
-        y <- arrange_genes(start, end + em_space + strwidth(name, cex=text_cex) + strwidth(dir_symbol, cex=text_cex))
+        y <- arrange_genes(start, end + space + strwidth(name, cex=text_cex) + strwidth(dir_symbol, cex=text_cex))
 
         maxy <- max(c(y, minrow))
         height <- 1/maxy
@@ -130,11 +130,11 @@ plot_genes <-
              end[i],   rect_bottom[i],
              col=colors[i], border=colors[i],
              lend=1, ljoin=1)
-        text(end[i] + em_space, y[i],
+        text(end[i] + space, y[i],
              name[i], adj=c(0, 0.5), col=colors[i],
              cex=text_cex)
         if(!is.na(strand[i]) && (strand[i] == "+" || strand[i] == '-'))
-            text(end[i] + em_space + strwidth(name[i], cex=text_cex), y[i],
+            text(end[i] + space + strwidth(name[i], cex=text_cex), y[i],
                  dir_symbol[i], adj=c(0, 0.5), col=colors[i],
                  cex=text_cex)
     }

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -104,7 +104,7 @@ plot_genes <-
         }
 
         # horizontal padding
-        xpad <- strwidth("m", cex=text_cex)
+        em_space <- strwidth("m", cex=text_cex)
 
         # figure out how to arrange genes vertically
         #   + number of rows of genes
@@ -114,7 +114,7 @@ plot_genes <-
         maxx <- max(c(end[1], start[1] + strwidth(name[1], cex=text_cex)))
         for(i in seq(along=y)[-1]) {
             for(j in 1:maxy) {
-                if(start[i] > maxx[j] + xpad) {
+                if(start[i] > maxx[j] + em_space) {
                     y[i] <- j
                     maxx[j] <- max(c(end[i], start[i] + strwidth(name[i], cex=text_cex)))
                     break

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -86,17 +86,14 @@ plot_genes <-
     # missing names: use ?
     name[is.na(name)] <- "?"
 
-    # right and left arrows (unicode symbol codes)
-    right_arrow <- "\u2192"
-    left_arrow <- "\u2190"
-
-    # add direction to gene name
+    # arrow annotation re direction, to place after gene name
+    dir_symbol <- rep(' ', length(name))
     right <- !is.na(strand) & strand == "+"
-    left <- !is.na(strand) & strand == "-"
     if(any(right))
-        name[right] <- paste(name[right], right_arrow)
+        dir_symbol[right] <- expression(phantom('') %->% phantom(''))
+    left <- !is.na(strand) & strand == "-"
     if(any(left))
-        name[left] <- paste(name[left], left_arrow)
+        dir_symbol[left] <- expression(phantom('') %<-% phantom(''))
 
     # initial determination of text size
     maxy <- minrow
@@ -115,7 +112,7 @@ plot_genes <-
 
         # figure out how to arrange genes vertically
         #   + number of rows of genes
-        y <- arrange_genes(start, end + 2*em_space + strwidth(name, cex=text_cex))
+        y <- arrange_genes(start, end + em_space + strwidth(name, cex=text_cex) + strwidth(dir_symbol, cex=text_cex))
 
         maxy <- max(c(y, minrow))
         height <- 1/maxy
@@ -136,6 +133,10 @@ plot_genes <-
         text(end[i] + em_space, y[i],
              name[i], adj=c(0, 0.5), col=colors[i],
              cex=text_cex)
+        if(!is.na(strand[i]) && (strand[i] == "+" || strand[i] == '-'))
+            text(end[i] + em_space + strwidth(name[i], cex=text_cex), y[i],
+                 dir_symbol[i], adj=c(0, 0.5), col=colors[i],
+                 cex=text_cex)
     }
 }
 

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -36,6 +36,13 @@ plot_genes <-
              colors=c("black", "red3", "green4", "blue3", "orange"),
              ...)
 {
+    # need both 'start' and 'stop' columns with no missing values
+    stopifnot(!any(is.na(genes$start)), !any(is.na(genes$stop)))
+
+    # make sure genes are ordered by their start values
+    if(any(diff(genes$start) < 0))
+        genes <- genes[order(genes$start, genes$stop),]
+
     # grab data
     start <- genes$start/10^6 # convert to Mbp
     end <- genes$stop/10^6   # convert to Mbp

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -38,12 +38,12 @@ plot_genes <-
 {
     # grab data
     start <- genes$start/10^6 # convert to Mbp
-    stop <- genes$stop/10^6   # convert to Mbp
+    end <- genes$stop/10^6   # convert to Mbp
     strand <- as.character(genes$strand)
     name <- as.character(genes$Name)
 
     if(is.null(xlim)) {
-        xlim <- range(c(start, stop), na.rm=TRUE)
+        xlim <- range(c(start, end), na.rm=TRUE)
     }
 
     internal_plot_genes <-
@@ -111,19 +111,19 @@ plot_genes <-
         n <- nrow(genes)
         y <- rep(NA, n)
         maxy <- y[1] <- 1
-        maxx <- max(c(stop[1], start[1] + strwidth(name[1], cex=text_cex)))
+        maxx <- max(c(end[1], start[1] + strwidth(name[1], cex=text_cex)))
         for(i in seq(along=y)[-1]) {
             for(j in 1:maxy) {
                 if(start[i] > maxx[j] + xpad) {
                     y[i] <- j
-                    maxx[j] <- max(c(stop[i], start[i] + strwidth(name[i], cex=text_cex)))
+                    maxx[j] <- max(c(end[i], start[i] + strwidth(name[i], cex=text_cex)))
                     break
                 }
             }
             if(is.na(y[i])) { # need new row
                 y[i] <- maxy + 1
                 maxy <- maxy + 1
-                maxx[maxy] <- max(c(stop[i], start[i] + strwidth(name[i], cex=text_cex)))
+                maxx[maxy] <- max(c(end[i], start[i] + strwidth(name[i], cex=text_cex)))
             }
         }
 
@@ -137,7 +137,7 @@ plot_genes <-
 
     colors <- rep(colors, length(y))
     for(i in seq(along=start)) {
-        rect(start[i], y[i]+(height*padding/4), stop[i], y[i]+height/2-(height*padding/4),
+        rect(start[i], y[i]+(height*padding/4), end[i], y[i]+height/2-(height*padding/4),
              col=colors[i], border=colors[i],
              lend=1, ljoin=1)
         text(start[i], y[i]+height*0.75,


### PR DESCRIPTION
Also:
- pull out calculation of genes' arrangement as separate function
- use `expression()` rather than unicode to get arrows (so they show up properly if one uses `pdf()`)
- make sure `start` and `stop` are provided, and that the genes are ordered
