### PR TITLE
Align scan1 output with map in plot_scan1, plot_scan1coef, ...

### DIFF
--- a/R/align_scan1_map.R
+++ b/R/align_scan1_map.R
@@ -1,0 +1,62 @@
+# All of these functions are also in qtl2scan, but I don't want to export them
+
+# align scan1 output with a map
+align_scan1_map <-
+    function(scan1_output, map)
+{
+    if(!is.list(map)) stop("map should be a list")
+
+    scan1_names <- rownames(scan1_output)
+    map_names <- map2markernames(map)
+    map_chr <- map2chr(map)
+
+    # perfectly fine
+    if(length(scan1_names) == length(map_names) &&
+       all(scan1_names == map_names))
+        return(list(scan1_output=scan1_output, map=map))
+
+    # subset scan1_output to markers in the map
+    #    and use order as in map
+    if(any(!(scan1_names %in% map_names))) {
+        scan1_attr <- attributes(scan1_output)
+        names_ordered <- map_names[map_names %in% scan1_names]
+        scan1_output <- scan1_output[names_ordered,,drop=FALSE]
+        for(a in c("SE", "sample_size", "hsq", "class"))
+            attr(scan1_output, a) <- scan1_attr[[a]]
+        scan1_names <- rownames(scan1_output)
+    }
+
+    # subset map to markers in scan1_output
+    if(any(!(map_names %in% scan1_names))) {
+        map_attr <- attributes(map)
+        keep <- map_names %in% scan1_names
+        uchr <- unique(map_chr[keep])
+        map <- map[uchr]
+        if("is_x_chr" %in% names(map_attr))
+            map_attr$is_x_chr <- map_attr$is_x_chr[uchr]
+        for(i in seq_along(map))
+            map[[i]] <- map[[i]][names(map[[i]]) %in% scan1_names]
+        for(a in c("is_x_chr", "class"))
+            attr(map, a) <- map_attr[[a]]
+    }
+
+    list(scan1_output=scan1_output, map=map)
+}
+
+# grab marker names as a vector
+map2markernames <-
+    function(map)
+{
+    nam <- unlist(lapply(map, names))
+    names(nam) <- NULL
+    nam
+}
+
+# grab chromosome IDs as a vector
+map2chr <-
+    function(map)
+{
+    chr <- rep(names(map), vapply(map, length, 0))
+    names(chr) <- map2markernames(map)
+    chr
+}

--- a/R/align_scan1_map.R
+++ b/R/align_scan1_map.R
@@ -15,6 +15,9 @@ align_scan1_map <-
        all(scan1_names == map_names))
         return(list(scan1_output=scan1_output, map=map))
 
+    if(!any(scan1_names %in% map_names))
+        stop("scan1 output and map have no markers in common")
+
     # subset scan1_output to markers in the map
     #    and use order as in map
     if(any(!(scan1_names %in% map_names))) {

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -78,6 +78,11 @@ plot_coef <-
 {
     if(is.null(map)) stop("map is NULL")
 
+    # align scan1 output and map
+    tmp <- align_scan1_map(x, map)
+    x <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(x) != length(unlist(map)))
         stop("nrow(x) [", nrow(x), "] != number of positions in map [",
              length(unlist(map)), "]")

--- a/R/plot_coef_and_lod.R
+++ b/R/plot_coef_and_lod.R
@@ -14,6 +14,11 @@ plot_coef_and_lod <-
 {
     if(is.null(map)) stop("map is NULL")
 
+    # align scan1 output and map
+    tmp <- align_scan1_map(x, map)
+    x <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(x) != length(unlist(map)))
         stop("nrow(x) [", nrow(x), "] != number of positions in map [",
              length(unlist(map)), "]")

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -78,6 +78,11 @@ plot_scan1 <-
 
     if(!is.list(map)) map <- list(" "=map) # if a vector, treat it as a list with no names
 
+    # align scan1 output and map
+    tmp <- align_scan1_map(x, map)
+    x <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(x) != length(unlist(map)))
         stop("nrow(x) [", nrow(x), "] != number of positions in map [",
              length(unlist(map)), "]")


### PR DESCRIPTION
For functions that take both output from `scan1()` (or `scan1coef()`) and a genetic map, such as `plot_scan1()` and `plot_scan1coef()`, added an internal function `align_scan1_map()` (which is an exactly copy of the function in [qtl2scan](https://github.com/rqtl/qtl2scan); I don't want to have to export it) that makes sure they are using the same set of markers. 

You then don't need to subset the map when you're dealing with `scan1()` results that are for a single chromosome. 