### PR TITLE
Hide a bunch of graphics parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,13 @@
 - Throughout, changed arguments like `hlines.col` to use an underscore
   rather than a period: `hlines_col`.
 
+- Hid a bunch of graphics parameters, to be passed via `...`, so that
+  the function definitions aren't so cluttered.
+
+- For `plot_snpasso()`, changed arguments `drop.hilit` and `col.hilit`
+  to `drop_hilit` and `col_hilit` for consistency with other
+  functions' argument names.
+
 
 ## qtl2plot 0.5-16 (2017-10-17)
 

--- a/R/CCcolors-data.R
+++ b/R/CCcolors-data.R
@@ -1,16 +1,18 @@
 #' @name CCcolors
 #' @aliases CCcolors
 #'
+#' @md
+#'
 #' @title Collaborative Cross colors
 #'
 #' @description A vector of 8 colors for use with the mouse
 #' Collaborative Cross and Diversity Outbreds.
 #'
 #' @details
-#' \code{CCorigcolors} are the original eight colors for the Collaborative Cross founder strains.
-#' \code{CCcolors} are slightly modified.
+#' `CCorigcolors` are the original eight colors for the Collaborative Cross founder strains.
+#' `CCcolors` are slightly modified.
 #'
-#' @source \url{http://compgen.unc.edu/wp/?page_id=577}
+#' @source <http://compgen.unc.edu/wp/?page_id=577>
 #'
 #' @keywords datasets
 #'

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -2,15 +2,17 @@
 #'
 #' Plot estimated QTL effects along a chromosomes.
 #'
+#' @md
+#'
 #' @param x Estimated QTL effects ("coefficients") as obtained from
-#' \code{\link[qtl2scan]{scan1coef}}.
+#' `\link[qtl2scan]{scan1coef}`.
 #'
 #' @param map A list of vectors of marker positions, as produced by
-#' \code{\link[qtl2geno]{insert_pseudomarkers}}.
+#' `\link[qtl2geno]{insert_pseudomarkers}`.
 #'
 #' @param columns Vector of columns to plot
 #'
-#' @param col Vector of colors, same length as \code{columns}. If
+#' @param col Vector of colors, same length as `columns`. If
 #' NULL, some default choices are made.
 #'
 #' @param scan1_output If provided, we make a two-panel plot with
@@ -31,22 +33,22 @@
 #' @importFrom graphics layout par
 #'
 #' @details
-#' \code{plot_coefCC()} is the same as \code{plot_coef()}, but forcing
-#' \code{columns=1:8} and using the Collaborative Cross colors,
-#' \code{\link{CCcolors}}.
+#' `plot_coefCC()` is the same as `plot_coef()`, but forcing
+#' `columns=1:8` and using the Collaborative Cross colors,
+#' `\link{CCcolors}`.
 #'
-#' @seealso \code{\link{CCcolors}}, \code{\link{plot_scan1}}, \code{\link{plot_snpasso}}
+#' @seealso `\link{CCcolors}`, `\link{plot_scan1}`, `\link{plot_snpasso}`
 #'
 #' @section Hidden graphics parameters:
-#' A number of graphics parameters can be passed via \code{...}. For
-#' example, \code{bgcolor} to control the background color, and things
-#' like \code{ylab} and \code{ylim}. These are not included as formal
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color, and things
+#' like `ylab` and `ylim`. These are not included as formal
 #' parameters in order to avoid cluttering the function definition.
 #'
-#' In the case that \code{scan1_output} is provided, \code{col},
-#' \code{ylab}, and \code{ylim} all control the panel with estimated
-#' QTL effects, while \code{col_lod}, \code{ylab_lod}, and
-#' \code{ylim_lod} control the LOD curve panel.
+#' In the case that `scan1_output` is provided, `col`,
+#' `ylab`, and `ylim` all control the panel with estimated
+#' QTL effects, while `col_lod`, `ylab_lod`, and
+#' `ylim_lod` control the LOD curve panel.
 #'
 #' @examples
 #' # load qtl2geno package for data and genoprob calculation

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -137,25 +137,17 @@ plot_coef <-
 #' @export
 #' @rdname plot_coef
 plot_coefCC <-
-    function(x, map, scan1_output=NULL, add=FALSE, gap=25, ylim=NULL,
-             bgcolor="gray90", altbgcolor="gray85",
-             ylab="QTL effects", ...)
+    function(x, map, scan1_output=NULL, add=FALSE, gap=25, ...)
 {
     plot_coef(x, map, columns=1:8, col=qtl2plot::CCcolors,
-              scan1_output=scan1_output, add=add, gap=gap,
-              ylim=ylim, bgcolor=bgcolor, altbgcolor=altbgcolor,
-              ylab=ylab, ...)
+              scan1_output=scan1_output, add=add, gap=gap, ...)
 }
 
 #' @export
 #' @rdname plot_coef
 plot.scan1coef <-
-    function(x, map, columns=1, col=NULL, scan1_output=NULL, add=FALSE, gap=25, ylim=NULL,
-             bgcolor="gray90", altbgcolor="gray85",
-             ylab="QTL effects", ...)
+    function(x, map, columns=1, col=NULL, scan1_output=NULL, add=FALSE, gap=25, ...)
 {
     plot_coef(x, map, columns=columns, col=col, scan1_output=scan1_output,
-              add=add, gap=gap, ylim=ylim,
-              bgcolor=bgcolor, altbgcolor=altbgcolor,
-              ylab=ylab, ...)
+              add=add, gap=gap, ...)
 }

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -22,15 +22,6 @@
 #'
 #' @param gap Gap between chromosomes.
 #'
-#' @param ylim y-axis limits. If NULL, we use the range of the plotted
-#' coefficients.
-#'
-#' @param bgcolor Background color for the plot.
-#'
-#' @param altbgcolor Background color for alternate chromosomes.
-#'
-#' @param ylab y-axis label
-#'
 #' @param top_panel_prop If `scan1_output` provided, this gives the
 #' proportion of the plot that is devoted to the top panel.
 #'
@@ -45,6 +36,17 @@
 #' \code{\link{CCcolors}}.
 #'
 #' @seealso \code{\link{CCcolors}}, \code{\link{plot_scan1}}, \code{\link{plot_snpasso}}
+#'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via \code{...}. For
+#' example, \code{bgcolor} to control the background color, and things
+#' like \code{ylab} and \code{ylim}. These are not included as formal
+#' parameters in order to avoid cluttering the function definition.
+#'
+#' In the case that \code{scan1_output} is provided, \code{col},
+#' \code{ylab}, and \code{ylim} all control the panel with estimated
+#' QTL effects, while \code{col_lod}, \code{ylab_lod}, and
+#' \code{ylim_lod} control the LOD curve panel.
 #'
 #' @examples
 #' # load qtl2geno package for data and genoprob calculation
@@ -72,9 +74,7 @@
 #' plot(coef, map[7], columns=1:3, col=c("slateblue", "violetred", "green3"))
 plot_coef <-
     function(x, map, columns=NULL, col=NULL, scan1_output=NULL,
-             add=FALSE, gap=25, ylim=NULL,
-             bgcolor="gray90", altbgcolor="gray85",
-             ylab="QTL effects", top_panel_prop=0.65, ...)
+             add=FALSE, gap=25, top_panel_prop=0.65, ...)
 {
     if(is.null(map)) stop("map is NULL")
 
@@ -89,8 +89,7 @@ plot_coef <-
 
     if(!is.null(scan1_output)) { # call internal function for both coef and LOD
         return(plot_coef_and_lod(x, map, columns=columns, col=col, scan1_output=scan1_output,
-                                 gap=gap, ylim=ylim, bgcolor=bgcolor, altbgcolor=altbgcolor,
-                                 ylab="QTL effects", xaxt=NULL, top_panel_prop=top_panel_prop,
+                                 gap=gap, xaxt=NULL, top_panel_prop=top_panel_prop,
                                  ...))
     }
 
@@ -111,15 +110,16 @@ plot_coef <-
             stop("Need at least ", length(columns), " colors")
     }
 
-    if(is.null(ylim)) {
-        ylim <- range(unclass(x)[,columns], na.rm=TRUE)
-        d <- diff(ylim) * 0.02 # add 2% on either side
-        ylim <- ylim + c(-d, d)
-    }
-
     plot_coef_internal <-
-        function(x, map, columns, ylim, col, add, gap, bgcolor, altbgcolor, ylab, ...)
+        function(x, map, columns, ylim=NULL, col, add, gap, bgcolor="gray90", altbgcolor="gray85",
+                 ylab="QTL effects", ...)
         {
+            if(is.null(ylim)) {
+                ylim <- range(unclass(x)[,columns], na.rm=TRUE)
+                d <- diff(ylim) * 0.02 # add 2% on either side
+                ylim <- ylim + c(-d, d)
+            }
+
             plot_scan1(x, map, lodcolumn=columns[1], ylim=ylim, col=col[1], add=add,
                        gap=gap, bgcolor=bgcolor, altbgcolor=altbgcolor,
                        ylab=ylab, ...)
@@ -129,8 +129,7 @@ plot_coef <-
                                add=TRUE, ...)
             }
         }
-    plot_coef_internal(unclass(x), map, columns=columns, ylim=ylim, col=col, add=add, gap=gap,
-                       bgcolor=bgcolor, altbgcolor=altbgcolor, ylab=ylab, ...)
+    plot_coef_internal(unclass(x), map, columns=columns, col=col, add=add, gap=gap, ...)
 }
 
 #' @export

--- a/R/plot_coef.R
+++ b/R/plot_coef.R
@@ -5,10 +5,10 @@
 #' @md
 #'
 #' @param x Estimated QTL effects ("coefficients") as obtained from
-#' `\link[qtl2scan]{scan1coef}`.
+#' [qtl2scan::scan1coef()].
 #'
 #' @param map A list of vectors of marker positions, as produced by
-#' `\link[qtl2geno]{insert_pseudomarkers}`.
+#' [qtl2geno::insert_pseudomarkers()].
 #'
 #' @param columns Vector of columns to plot
 #'
@@ -35,9 +35,9 @@
 #' @details
 #' `plot_coefCC()` is the same as `plot_coef()`, but forcing
 #' `columns=1:8` and using the Collaborative Cross colors,
-#' `\link{CCcolors}`.
+#' [CCcolors].
 #'
-#' @seealso `\link{CCcolors}`, `\link{plot_scan1}`, `\link{plot_snpasso}`
+#' @seealso [CCcolors], [plot_scan1()], [plot_snpasso()]
 #'
 #' @section Hidden graphics parameters:
 #' A number of graphics parameters can be passed via `...`. For

--- a/R/plot_coef_and_lod.R
+++ b/R/plot_coef_and_lod.R
@@ -52,7 +52,7 @@ plot_coef_and_lod <-
               vlines.lwd=vlines.lwd, vlines.lty=vlines.lty, ...)
 
     par(mar=bottom_mar)
-    plot_scan1(scan1_output, map, lodcolumn=1, col=col_lod,
+    plot_scan1(scan1_output, map, lodcolumn=1, col=col_lod, ylab=ylab_lod,
                add=FALSE, gap=gap, vlines=vlines, vlines.col=vlines.col,
                vlines.lwd=vlines.lwd, vlines.lty=vlines.lty, ...)
 }

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -16,7 +16,7 @@
 #' @param stop_field Character string with name of column containing the genes' stop positions.
 #' @param strand_field Character string with name of column containing the genes' strands.
 #' @param name_field Character string with name of column containing the genes' names.
-#' @param ... Optional arguments passed to `\link[graphics]{plot}`.
+#' @param ... Optional arguments passed to [graphics::plot()].
 #'
 #' @return None.
 #'

--- a/R/plot_genes.R
+++ b/R/plot_genes.R
@@ -3,10 +3,11 @@
 #' Plot gene locations for a genomic interval, as rectangles with gene
 #' symbol (and arrow indicating strand/direction) below.
 #'
-#' @param genes Data frame containing \code{start} and \code{stop} in
-#' bp, \code{strand} (as \code{"-"}, \code{"+"}, or \code{NA}), and
-#' \code{Name}.
-#' @param xlim x-axis limits (in Mbp)
+#' @md
+#'
+#' @param genes Data frame containing `start` and `stop` in
+#' bp, `strand` (as `"-"`, `"+"`, or `NA`), and
+#' `Name`.
 #' @param minrow Minimum number of rows of genes in the plot
 #' @param padding Proportion to pad with white space around the genes
 #' @param colors Vectors of colors, used sequentially and then re-used.
@@ -15,13 +16,18 @@
 #' @param stop_field Character string with name of column containing the genes' stop positions.
 #' @param strand_field Character string with name of column containing the genes' strands.
 #' @param name_field Character string with name of column containing the genes' names.
-#' @param ... Optional arguments passed to \code{\link[graphics]{plot}}.
+#' @param ... Optional arguments passed to `\link[graphics]{plot}`.
 #'
 #' @return None.
 #'
 #' @keywords hgraphics
 #' @export
 #' @importFrom graphics strheight strwidth text plot par rect abline box
+#'
+#' @section Hidden graphics parameters:
+#' Graphics parameters can be passed via `...`. For
+#' example, `xlim` to control the x-axis limits.
+#' These are not included as formal
 #'
 #' @examples
 #' genes <- data.frame(chr = c("6", "6", "6", "6", "6", "6", "6", "6"),
@@ -37,7 +43,7 @@
 
 # create an empty plot with test x- and y-axis limits
 plot_genes <-
-    function(genes, xlim=NULL, minrow=4, padding=0.2,
+    function(genes, minrow=4, padding=0.2,
              colors=c("black", "red3", "green4", "blue3", "orange"),
              scale_pos=1e-6, start_field="start", stop_field="stop",
              strand_field="strand", name_field="Name", ...)
@@ -70,17 +76,17 @@ plot_genes <-
     strand <- as.character(genes[,strand_field])
     name <- as.character(genes[,name_field])
 
-    if(is.null(xlim)) {
-        xlim <- range(c(start, end), na.rm=TRUE)
-    }
-
-    internal_plot_genes <-
+    plot_genes_internal <-
         function(xlab="Position (Mbp)", xaxs="i",
                  bgcolor="gray92", xat=NULL,
-                 mgp=c(1.6,0.2,0),
+                 mgp=c(1.6,0.2,0), xlim=NULL,
                  vlines=NULL, vlines_col="white",
                  vlines_lwd=1, vlines_lty=1)
         {
+            if(is.null(xlim)) {
+                xlim <- range(c(start, end), na.rm=TRUE)
+            }
+
             plot(0, 0, type="n",
                  xlim=xlim,   xlab=xlab, xaxs=xaxs, xaxt="n",
                  ylim=c(1,0), ylab="", yaxs="i", yaxt="n", mgp=mgp)
@@ -102,7 +108,7 @@ plot_genes <-
             box()
         }
 
-    internal_plot_genes(...)
+    plot_genes_internal(...)
 
     # missing names: use ?
     name[is.na(name)] <- "?"

--- a/R/plot_genoprob.R
+++ b/R/plot_genoprob.R
@@ -2,28 +2,32 @@
 #'
 #' Plot the genotype probabilities for one individual on one chromosome, as a heat map.
 #'
-#' @param probs Genotype probabilities (as produced by \code{\link[qtl2geno]{calc_genoprob}})
-#' or allele dosages (as produced by \code{\link[qtl2geno]{genoprob_to_alleleprob}}).
+#' @md
+#'
+#' @param probs Genotype probabilities (as produced by [qtl2geno::calc_genoprob()])
+#' or allele dosages (as produced by qtl2geno::genoprob_to_alleleprob()]).
 #' @param map Marker map (a list of vectors of marker positions).
 #' @param ind Individual to plot, either a numeric index or an ID.
 #' @param chr Selected chromosome to plot; a single character string.
 #' @param geno Optional vector of genotypes or alleles to be shown
 #' (vector of integers or character strings)
-#' @param color_scheme Color scheme for the heatmap (ignored if \code{col} is provided).
+#' @param color_scheme Color scheme for the heatmap (ignored if `col` is provided).
 #' @param col Optional vector of colors for the heatmap.
 #' @param threshold Threshold for genotype probabilities; only genotypes that achieve
 #' this value somewhere on the chromosome will be shown.
 #' @param swap_axes If TRUE, swap the axes, so that the genotypes are
 #' on the x-axis and the chromosome position is on the y-axis.
-#' @param hlines Position of horizontal grid lines (use \code{NA} to avoid lines).
-#' @param hlines_col Color of horizontal grid lines.
-#' @param hlines_lwd Line width of horizontal grid lines.
-#' @param hlines_lty Line type of horizontal grid lines.
-#' @param vlines Position of vertical grid lines (use \code{NA} to avoid lines).
-#' @param vlines_col Color of vertical grid lines.
-#' @param vlines_lwd Line width of vertical grid lines.
-#' @param vlines_lty Line type of vertical grid lines.
-#' @param ... Additional graphics parameters passed to \code{\link[graphics]{image}}.
+#' @param ... Additional graphics parameters passed to [graphics::image()].
+#'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `hlines`, `hlines_col`, `hlines_lwd`, and `hlines_lty` to
+#' control the horizontal grid lines. (Use `hlines=NA` to avoid
+#' plotting horizontal grid lines.) Similarly `vlines`, `vlines_col`,
+#' `vlines_lwd`, and `vlines_lty` for vertical grid lines. You can
+#' also use many standard graphics parameters like `xlab` and `xlim`.
+#' These are not included as formal parameters in order to avoid
+#' cluttering the function definition.
 #'
 #' @examples
 #' # load data and calculate genotype probabilities
@@ -81,10 +85,7 @@
 plot_genoprob <-
     function(probs, map, ind=1, chr=NULL, geno=NULL,
              color_scheme=c("gray", "viridis"), col=NULL,
-             threshold=0, swap_axes=FALSE,
-             hlines=NULL, hlines_col="#B3B3B370", hlines_lwd=1, hlines_lty=1,
-             vlines=NULL, vlines_col="#B3B3B370", vlines_lwd=1, vlines_lty=1,
-             ...)
+             threshold=0, swap_axes=FALSE, ...)
 {
     # check inputs
     if(is.null(map)) stop("map is NULL")
@@ -148,10 +149,7 @@ plot_genoprob <-
     if(any(diff(map) < tol))
         map <- map + seq(0, tol, length.out=length(map))
 
-    plot_genoprob_internal(probs, map, col=col, swap_axes=swap_axes,
-                           hlines=hlines, hlines_col=hlines_col, hlines_lty=hlines_lty, hlines_lwd=hlines_lwd,
-                           vlines=vlines, vlines_col=vlines_col, vlines_lty=vlines_lty, vlines_lwd=vlines_lwd,
-                           ...)
+    plot_genoprob_internal(probs, map, col=col, swap_axes=swap_axes, ...)
 
 }
 
@@ -161,8 +159,8 @@ plot_genoprob <-
 plot_genoprob_internal <-
     function(probs, map, col=NULL, swap_axes=FALSE,
              zlim=c(0,1), xlab=NULL, ylab=NULL, las=NULL,
-             hlines=NULL, hlines_col="gray70", hlines_lwd=1, hlines_lty=1,
-             vlines=NULL, vlines_col="gray70", vlines_lwd=1, vlines_lty=1,
+             hlines=NULL, hlines_col="#B3B3B370", hlines_lwd=1, hlines_lty=1,
+             vlines=NULL, vlines_col="#B3B3B370", vlines_lwd=1, vlines_lty=1,
              mgp.x=c(2.6,0.5,0), mgp.y=c(2.6,0.5,0), mgp=NULL,
              ...)
 {

--- a/R/plot_genoprob.R
+++ b/R/plot_genoprob.R
@@ -144,11 +144,6 @@ plot_genoprob <-
         else if(color_scheme=="viridis") col <- viridis_qtl2(256)
     }
 
-    # separate positions if necessary
-    tol <- 1e-6
-    if(any(diff(map) < tol))
-        map <- map + seq(0, tol, length.out=length(map))
-
     plot_genoprob_internal(probs, map, col=col, swap_axes=swap_axes, ...)
 
 }
@@ -168,6 +163,11 @@ plot_genoprob_internal <-
     if(!is.null(mgp)) mgp.x <- mgp.y <- mgp
     if(is.null(dots$xaxt)) dots$xaxt <- par("xaxt")
     if(is.null(dots$yaxt)) dots$yaxt <- par("yaxt")
+
+    # separate positions if necessary
+    tol <- 1e-6
+    if(any(diff(map) < tol))
+        map <- map + seq(0, tol, length.out=length(map))
 
     if(swap_axes) {
         probs <- t(probs)

--- a/R/plot_genoprob.R
+++ b/R/plot_genoprob.R
@@ -29,6 +29,8 @@
 #' These are not included as formal parameters in order to avoid
 #' cluttering the function definition.
 #'
+#' @seealso [plot_genoprobcomp()]
+#'
 #' @examples
 #' # load data and calculate genotype probabilities
 #' library(qtl2geno)

--- a/R/plot_genoprobcomp.R
+++ b/R/plot_genoprobcomp.R
@@ -2,9 +2,11 @@
 #'
 #' Plot a comparison of two sets of genotype probabilities for one individual on one chromosome, as a heat map.
 #'
-#' @param probs1 Genotype probabilities (as produced by \code{\link[qtl2geno]{calc_genoprob}})
-#' or allele dosages (as produced by \code{\link[qtl2geno]{genoprob_to_alleleprob}}).
-#' @param probs2 A second set of genotype probabilities, just like \code{probs1}.
+#' @md
+#'
+#' @param probs1 Genotype probabilities (as produced by [qtl2geno::calc_genoprob()])
+#' or allele dosages (as produced by [qtl2geno::genoprob_to_alleleprob()]).
+#' @param probs2 A second set of genotype probabilities, just like `probs1`.
 #' @param map Marker map (a list of vectors of marker positions).
 #' @param ind Individual to plot, either a numeric index or an ID.
 #' @param chr Selected chromosome to plot; a single character string.
@@ -15,15 +17,7 @@
 #' @param n_colors Number of colors in each color scale.
 #' @param swap_axes If TRUE, swap the axes, so that the genotypes are
 #' on the x-axis and the chromosome position is on the y-axis.
-#' @param hlines Position of horizontal grid lines (use \code{NA} to avoid lines).
-#' @param hlines_col Color of horizontal grid lines.
-#' @param hlines_lwd Line width of horizontal grid lines.
-#' @param hlines_lty Line type of horizontal grid lines.
-#' @param vlines Position of vertical grid lines (use \code{NA} to avoid lines).
-#' @param vlines_col Color of vertical grid lines.
-#' @param vlines_lwd Line width of vertical grid lines.
-#' @param vlines_lty Line type of vertical grid lines.
-#' @param ... Additional graphics parameters passed to \code{\link[graphics]{image}}.
+#' @param ... Additional graphics parameters passed to [graphics::image()].
 #'
 #' @details
 #' We plot the first set of probabilities in the range white to blue
@@ -52,10 +46,7 @@
 #' @importFrom grDevices rgb
 plot_genoprobcomp <-
     function(probs1, probs2, map, ind=1, chr=NULL, geno=NULL,
-             threshold=0, n_colors=256, swap_axes=FALSE,
-             hlines=NULL, hlines_col="#B3B3B370", hlines_lwd=1, hlines_lty=1,
-             vlines=NULL, vlines_col="#B3B3B370", vlines_lwd=1, vlines_lty=1,
-             ...)
+             threshold=0, n_colors=256, swap_axes=FALSE, ...)
 {
     # check inputs
     if(is.null(map)) stop("map is NULL")
@@ -162,9 +153,6 @@ plot_genoprobcomp <-
         map <- map + seq(0, tol, length.out=length(map))
 
     plot_genoprob_internal(probs, map, col=joint_colors, swap_axes=swap_axes,
-                           hlines=hlines, hlines_col=hlines_col, hlines_lty=hlines_lty, hlines_lwd=hlines_lwd,
-                           vlines=vlines, vlines_col=vlines_col, vlines_lty=vlines_lty, vlines_lwd=vlines_lwd,
-                           zlim=c(1,n_colors^2),
-                           ...)
+                           zlim=c(1,n_colors^2), ...)
 
 }

--- a/R/plot_genoprobcomp.R
+++ b/R/plot_genoprobcomp.R
@@ -25,6 +25,8 @@
 #' them, for colors that are white, some amount of blue or red, or
 #' where both are large something like blackish purple.
 #'
+#' @seealso [plot_genoprob()]
+#'
 #' @examples
 #' library(qtl2geno)
 #' iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))

--- a/R/plot_genoprobcomp.R
+++ b/R/plot_genoprobcomp.R
@@ -147,11 +147,6 @@ plot_genoprobcomp <-
     red[,2] <- red[,3] <-   rep(seq(1, 0.2, length=n_colors), n_colors)
     joint_colors <- apply(blue*red, 1, function(a) rgb(a[1], a[2], a[3], maxColorValue=1))
 
-    # separate positions if necessary
-    tol <- 1e-6
-    if(any(diff(map) < tol))
-        map <- map + seq(0, tol, length.out=length(map))
-
     plot_genoprob_internal(probs, map, col=joint_colors, swap_axes=swap_axes,
                            zlim=c(1,n_colors^2), ...)
 

--- a/R/plot_onegeno.R
+++ b/R/plot_onegeno.R
@@ -2,9 +2,11 @@
 #'
 #' Plot one individual's genome-wide genotypes
 #'
+#' @md
+#'
 #' @param geno Imputed phase-known genotypes, as a list of matrices
-#'     (as produced by \code{\link[qtl2geno]{maxmarg}}) or a list of
-#'     three-dimensional arrays (as produced by \code{\link[qtl2geno]{guess_phase}}).
+#'     (as produced by [qtl2geno::maxmarg()]) or a list of
+#'     three-dimensional arrays (as produced by [qtl2geno::guess_phase()]).
 #' @param map Marker map (a list of vectors of marker positions).
 #' @param ind Individual to plot, either a numeric index or an ID.
 #' @param chr Selected chromosomes to plot; a vector of character strings.
@@ -13,11 +15,15 @@
 #' @param swap_axes If TRUE, swap the axes, so that the chromosomes run horizontally.
 #' @param border Color of outer border around chromosome rectangles.
 #' @param shift If TRUE, shift the chromosomes so they all start at 0.
-#' @param bgcolor Color for background rectangle
 #' @param chrwidth Total width of rectangles for each chromosome, as a
 #'     fraction of the distance between them.
 #' @param ... Additional graphics parameters
 #'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color.
+#' These are not included as formal parameters in order to avoid
+#' cluttering the function definition.
 #'
 #' @examples
 #' # load data and calculate genotype probabilities
@@ -61,7 +67,7 @@ plot_onegeno <-
     function(geno, map, ind=1, chr=NULL,
              col=NULL, na_col="white",
              swap_axes=FALSE,
-             border="black", shift=FALSE, bgcolor="gray90",
+             border="black", shift=FALSE,
              chrwidth=0.5, ...)
 {
     if(is.null(map)) stop("map is NULL")
@@ -321,7 +327,7 @@ plot_onegeno <-
 
     plot_onegeno_internal(geno, map, col=col, na_col=na_col,
                           swap_axes=swap_axes, border=border,
-                          bgcolor=bgcolor, chrwidth=chrwidth, ...)
+                          chrwidth=chrwidth, ...)
 
 
 }

--- a/R/plot_peaks.R
+++ b/R/plot_peaks.R
@@ -2,22 +2,29 @@
 #'
 #' Plot QTL peak locations (possibly with intervals) for multiple traits.
 #'
+#' @md
+#'
 #' @param peaks Data frame such as that produced by
-#'     \code{\link[qtl2scan]{find_peaks}}) containing columns
-#'     \code{chr}, \code{pos}, \code{lodindex}, and \code{lodcolumn}.
-#'     May also contain columns \code{ci_lo} and \code{ci_hi}, in
+#'     [qtl2scan::find_peaks()]) containing columns
+#'     `chr`, `pos`, `lodindex`, and `lodcolumn`.
+#'     May also contain columns `ci_lo` and `ci_hi`, in
 #'     which case intervals will be plotted.
 #' @param map Marker map, used to get chromosome lengths (and start
 #'     and end positions).
 #' @param chr Selected chromosomes to plot; a vector of character
 #'     strings.
 #' @param tick_height Height of tick marks at the peaks (a number between 0 and 1).
-#' @param bgcolor Background color for the plot.
-#' @param altbgcolor Background color for alternate chromosomes.
 #' @param gap Gap between chromosomes.
 #' @param ... Additional graphics parameters
 #'
-#' @seealso \code{\link[qtl2scan]{find_peaks}}
+#' @seealso [qtl2scan::find_peaks()]
+#'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color and
+#' `altbgcolor` to control the background color on alternate chromosomes.
+#' These are not included as formal parameters in order to avoid
+#' cluttering the function definition.
 #'
 #' @export
 #' @importFrom graphics plot segments abline par axis title box rect
@@ -54,8 +61,7 @@
 
 plot_peaks <-
     function(peaks, map, chr=NULL, tick_height = 0.3,
-             gap=25, bgcolor="gray90", altbgcolor="gray85",
-             ...)
+             gap=25, ...)
 {
     if(is.null(map)) stop("map is NULL")
 
@@ -74,7 +80,7 @@ plot_peaks <-
 
     plot_peaks_internal <-
         function(peaks, map, tick_height,
-                 gap, bgcolor, algbgcolor,
+                 gap, bgcolor="gray90", altbgcolor="gray85",
                  lwd=2, col="slateblue", xlab=NULL, ylab="",
                  xlim=NULL, ylim=NULL, xaxs="i", yaxs="i",
                  main="", mgp.x=c(2.6, 0.5, 0), mgp.y=c(2.6, 0.5, 0),
@@ -183,6 +189,6 @@ plot_peaks <-
         }
 
     plot_peaks_internal(peaks=peaks, map=map, tick_height=tick_height,
-                        gap=gap, bgcolor=bgcolor, algbgcolor=altbgcolor, ...)
+                        gap=gap, ...)
 
 }

--- a/R/plot_pxg.R
+++ b/R/plot_pxg.R
@@ -2,14 +2,16 @@
 #'
 #' Plot phenotype vs genotype for a single putative QTL and a single phenotype.
 #'
+#' @md
+#'
 #' @param geno Vector of genotypes, as produced by
-#' \code{\link[qtl2geno]{maxmarg}} with specific \code{chr} and
-#' \code{pos}.
+#' [qtl2geno::maxmarg()] with specific `chr` and
+#' `pos`.
 #' @param pheno Vector of phenotypes.
 #' @param sort If TRUE, sort genotypes from largest to smallest.
 #' @param SEmult If specified, interval estimates of the within-group
-#' averages will be displayed, as \code{mean +/- SE * SEmult}.
-#' @param pooledSD If TRUE and \code{SEmult} is specified, calculated
+#' averages will be displayed, as `mean +/- SE * SEmult`.
+#' @param pooledSD If TRUE and `SEmult` is specified, calculated
 #' a pooled within-group SD. Otherwise, get separate estimates of
 #' the within-group SD for each group.
 #' @param swap_axes If TRUE, swap the axes, so that the genotypes are
@@ -17,28 +19,27 @@
 #' @param jitter Amount to jitter the points horizontally, if a vector
 #' of length > 0, it is taken to be the actual jitter amounts
 #' (with values between -0.5 and 0.5).
-#' @param seg_width Width of segments at the estimated within-group averages
-#' @param seg_lwd Line width used to plot estimated within-group averages
-#' @param seg_col Line color used to plot estimated within-group averages
-#' @param bgcolor Background color for the plot.
-#' @param hlines Locations of horizontal grid lines.
-#' @param hlines_col Color of horizontal grid lines
-#' @param hlines_lty Line type of horizontal grid lines
-#' @param hlines_lwd Line width of horizontal grid lines
-#' @param vlines Locations of vertical grid lines.
-#' @param vlines_col Color of vertical grid lines
-#' @param vlines_lty Line type of vertical grid lines
-#' @param vlines_lwd Line width of vertical grid lines
 #' @param force_labels If TRUE, force all genotype labels to be shown.
 #' @param alternate_labels If TRUE, place genotype labels in two rows
 #' @param omit_points If TRUE, omit the points, just plotting the averages (and, potentially, the +/- SE intervals).
-#' @param ... Additional graphics parameters, passed to \code{\link[graphics]{plot}}.
+#' @param ... Additional graphics parameters, passed to [graphics::plot()].
 #'
 #' @export
 #' @importFrom graphics par plot segments title axis points
 #' @importFrom stats lm runif sd
 #'
-#' @seealso \code{\link{plot_coef}}
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color, and
+#' `seg_width`, `seg_lwd`, and `seg_col` to control the lines at the
+#' confidence intervals. Further, `hlines`, `hlines_col`,
+#' `hlines_lwd`, and `hlines_lty` to control the horizontal grid
+#' lines. (Use `hlines=NA` to avoid plotting horizontal grid lines.)
+#' Similarly `vlines`, `vlines_col`, `vlines_lwd`, and `vlines_lty`
+#' for vertical grid lines. These are not included as formal
+#' parameters in order to avoid cluttering the function definition.
+#'
+#' @seealso [plot_coef()]
 #'
 #' @examples
 #' # load qtl2geno package for data and genoprob calculation
@@ -72,10 +73,7 @@
 #'          omit_points=TRUE, SEmult=2)
 plot_pxg <-
     function(geno, pheno, sort=TRUE, SEmult=NULL, pooledSD=TRUE,
-             swap_axes=FALSE, jitter=0.2, bgcolor="gray90",
-             seg_width=NULL, seg_lwd=2, seg_col="black",
-             hlines=NULL, hlines_col=NULL, hlines_lty=NULL, hlines_lwd=NULL,
-             vlines=NULL, vlines_col=NULL, vlines_lty=NULL, vlines_lwd=NULL,
+             swap_axes=FALSE, jitter=0.2,
              force_labels=TRUE, alternate_labels=FALSE,
              omit_points=FALSE, ...)
 {
@@ -133,7 +131,7 @@ plot_pxg <-
 
     plot_pxg_internal <-
         function(geno, pheno, swap_axes=FALSE, bgcolor="gray90",
-                 seg_width=NULL, seg_lwd=2, seg_col="slateblue",
+                 seg_width=NULL, seg_lwd=2, seg_col="black",
                  hlines=NULL, hlines_col=NULL, hlines_lty=NULL, hlines_lwd=NULL,
                  vlines=NULL, vlines_col=NULL, vlines_lty=NULL, vlines_lwd=NULL,
                  xlim=NULL, ylim=NULL,
@@ -305,10 +303,8 @@ plot_pxg <-
             box()
         }
 
-    plot_pxg_internal(geno, pheno, swap_axes=swap_axes, bgcolor=bgcolor,
-                      seg_width=seg_width, seg_lwd=seg_lwd, seg_col=seg_col,
-                      hlines=hlines, hlines_col=hlines_col, hlines_lty=hlines_lty, hlines_lwd=hlines_lwd,
-                      vlines_col=vlines_col, vlines_lty=vlines_lty, vlines_lwd=vlines_lwd, ...)
+    plot_pxg_internal(geno, pheno, swap_axes=swap_axes, ...)
+
 
     # return mean and SE
     invisible(cbind(mean=me, SE=se))

--- a/R/plot_scan1.R
+++ b/R/plot_scan1.R
@@ -2,10 +2,12 @@
 #'
 #' Plot LOD curves for a genome scan
 #'
-#' @param x Output of \code{\link[qtl2scan]{scan1}}.
+#' @md
+#'
+#' @param x Output of [qtl2scan::scan1()].
 #'
 #' @param map A list of vectors of marker positions, as produced by
-#' \code{\link[qtl2geno]{insert_pseudomarkers}}.
+#' [qtl2geno::insert_pseudomarkers()].
 #'
 #' @param lodcolumn LOD score column to plot (a numeric index, or a
 #' character string for a column name). Only one value allowed.
@@ -16,15 +18,18 @@
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
-#' @param bgcolor Background color for the plot.
-#'
-#' @param altbgcolor Background color for alternate chromosomes.
-#'
 #' @param gap Gap between chromosomes.
 #'
 #' @param ... Additional graphics parameters.
 #'
-#' @seealso \code{\link{plot_coef}}, \code{\link{plot_coefCC}}, \code{\link{plot_snpasso}}
+#' @seealso [plot_coef()], [plot_coefCC()], [plot_snpasso()]
+#'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color and
+#' `altbgcolor` to control the background color on alternate chromosomes.
+#' These are not included as formal parameters in order to avoid
+#' cluttering the function definition.
 #'
 #' @export
 #' @importFrom graphics plot rect lines par axis title abline box
@@ -71,8 +76,7 @@
 #' plot(out, map, lodcolumn="liver", ylim=ylim)
 #' plot(out, map, lodcolumn="spleen", col="violetred", add=TRUE)
 plot_scan1 <-
-    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25,
-             bgcolor="gray90", altbgcolor="gray85", ...)
+    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25, ...)
 {
     if(is.null(map)) stop("map is NULL")
 
@@ -115,7 +119,7 @@ plot_scan1 <-
     #    but still have some defaults for them
     plot_scan1_internal <-
         function(map, lod, add=FALSE, gap,
-                 bgcolor, altbgcolor,
+                 bgcolor="gray90", altbgcolor="gray85",
                  lwd=2, col="darkslateblue", xlab=NULL, ylab="LOD score",
                  xlim=NULL, ylim=NULL, xaxs="i", yaxs="i",
                  main="", mgp.x=c(2.6, 0.5, 0), mgp.y=c(2.6, 0.5, 0),
@@ -216,26 +220,21 @@ plot_scan1 <-
         }
 
     # make the plot
-    plot_scan1_internal(map=map, lod=lod, add=add, gap=gap,
-                       bgcolor=bgcolor, altbgcolor=altbgcolor,
-                       ...)
+    plot_scan1_internal(map=map, lod=lod, add=add, gap=gap, ...)
 }
 
 
 #' @export
 #' @rdname plot_scan1
 plot.scan1 <-
-    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25,
-             bgcolor="gray90", altbgcolor="gray85", ...)
+    function(x, map, lodcolumn=1, chr=NULL, add=FALSE, gap=25, ...)
 {
     # if map looks like snpinfo, assume this is a snp asso result and use plot_snpasso()
     if(is.data.frame(map) && "index" %in% names(map)) {
-        plot_snpasso(x, snpinfo=map, add=add, gap=gap, bgcolor=bgcolor,
-                     altbgcolor=altbgcolor, ...)
+        plot_snpasso(x, snpinfo=map, add=add, gap=gap, ...)
     }
     else { # mostly, use plot_scan1()
-        plot_scan1(x, map=map, lodcolumn=lodcolumn, chr=chr, add=add, gap=gap,
-                   bgcolor=bgcolor, altbgcolor=altbgcolor, ...)
+        plot_scan1(x, map=map, lodcolumn=lodcolumn, chr=chr, add=add, gap=gap, ...)
     }
 }
 

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -31,9 +31,9 @@
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
 #'
-#' @param drop.hilit SNPs with LOD score within this amount of the maximum SNP association will be highlighted.
+#' @param drop_hilit SNPs with LOD score within this amount of the maximum SNP association will be highlighted.
 #'
-#' @param col.hilit Color of highlighted points
+#' @param col_hilit Color of highlighted points
 #'
 #' @param col Color of other points
 #'
@@ -96,7 +96,7 @@
 #' plot_snpasso(out_snps, snpinfo, show_all_snps=FALSE)
 #'
 #' # highlight the top snps (with LOD within 1.5 of max)
-#' plot(out_snps, snpinfo, drop.hilit=1.5)
+#' plot(out_snps, snpinfo, drop_hilit=1.5)
 #' }
 #'
 #' @seealso [plot_scan1()], [plot_coef()], [plot_coefCC()]
@@ -104,7 +104,7 @@
 #'
 plot_snpasso <-
     function(scan1output, snpinfo, show_all_snps=TRUE, add=FALSE,
-             drop.hilit=NA, col.hilit="violetred", col="darkslateblue",
+             drop_hilit=NA, col_hilit="violetred", col="darkslateblue",
              gap=25, ...)
 {
     uindex <- unique(snpinfo$index)
@@ -132,8 +132,8 @@ plot_snpasso <-
     if(is.null(ylim))
         ylim <- c(0, maxlod*1.02)
 
-    if(!is.na(drop.hilit) && !is.null(drop.hilit))
-        col <- c(col, col.hilit)[(scan1output >= maxlod-drop.hilit)+1]
+    if(!is.na(drop_hilit) && !is.null(drop_hilit))
+        col <- c(col, col_hilit)[(scan1output >= maxlod-drop_hilit)+1]
 
     # internal function to give defaults to hidden graphics parameters
     plot_snpasso_internal <-

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -86,7 +86,6 @@
 #' out_snps <- scan1(snp_pr, DOex$pheno)
 #'
 #' # plot results
-#' library(qtl2plot)
 #' plot_snpasso(out_snps, snpinfo)
 #'
 #' # can also just type plot()
@@ -129,22 +128,34 @@ plot_snpasso <-
     # maximum LOD
     maxlod <- max(unclass(scan1output)[,1], na.rm=TRUE)
 
-    if(is.null(ylim))
-        ylim <- c(0, maxlod*1.02)
-
-    if(!is.na(drop_hilit) && !is.null(drop_hilit))
-        col <- c(col, col_hilit)[(scan1output >= maxlod-drop_hilit)+1]
-
     # internal function to give defaults to hidden graphics parameters
     plot_snpasso_internal <-
         function(pch=16, cex=0.5, ylim=NULL, bgcolor="gray90",
-                 altbgcolor="gray85", ...)
+                 altbgcolor="gray85",
+                 drop_hilit=NA, col_hilit="violetred",
+                 drop.hilit=NULL, col.hilit=NULL, ...)
     {
+        if(missing(drop_hilit) && !is.null(drop.hilit)) {
+            warning("drop.hilit is deprecated; use drop_hilit")
+            drop_hilit <- drop.hilit
+        }
+
+        if(missing(col_hilit) && !is.null(col.hilit)) {
+            warning("col.hilit is deprecated; use col_hilit")
+            col_hilit <- col.hilit
+        }
+
+        if(is.null(ylim))
+            ylim <- c(0, maxlod*1.02)
+
+        if(!is.na(drop_hilit) && !is.null(drop_hilit))
+            col <- c(col, col_hilit)[(scan1output >= maxlod-drop_hilit)+1]
+
         plot_scan1(scan1output, map, lodcolumn=1, bgcolor=bgcolor, altbgcolor=altbgcolor, ylim=ylim,
                    gap=gap, add=add, col = col, type="p", cex=cex, pch=pch, ...)
     }
 
-    plot_snpasso_internal(...)
+    plot_snpasso_internal(drop_hilit=drop_hilit, col_hilit=col_hilit, ...)
 }
 
 

--- a/R/plot_snpasso.R
+++ b/R/plot_snpasso.R
@@ -2,38 +2,34 @@
 #'
 #' Plot SNP associations, with possible expansion from distinct snps to all snps.
 #'
-#' @param scan1output Output of \code{\link[qtl2scan]{scan1}} using
+#' @md
+#'
+#' @param scan1output Output of [qtl2scan::scan1()] using
 #' SNP probabilities derived by
-#' \code{\link[qtl2scan]{genoprob_to_snpprob}}.
+#' [qtl2scan::genoprob_to_snpprob()].
 #'
 #' @param snpinfo Data frame with SNP information with the following
 #'     columns (the last three are generally derived from with
-#'     \code{\link[qtl2scan]{index_snps}}):
-#' \itemize{
-#' \item \code{chr} - Character string or factor with chromosome
-#' \item \code{pos} - Position (in same units as in the \code{"map"}
-#'     attribute in \code{genoprobs}.
-#' \item \code{sdp} - Strain distribution pattern: an integer, between
+#'     [qtl2scan::index_snps()]):
+#' * `chr` - Character string or factor with chromosome
+#' * `pos` - Position (in same units as in the `"map"`
+#'     attribute in `genoprobs`.
+#' * `sdp` - Strain distribution pattern: an integer, between
 #'     1 and \eqn{2^n - 2} where \eqn{n} is the number of strains, whose
 #'     binary encoding indicates the founder genotypes
-#' \item \code{snp} - Character string with SNP identifier (if
+#' * `snp` - Character string with SNP identifier (if
 #'     missing, the rownames are used).
-#' \item \code{index} - Indices that indicate equivalent
+#' * `index` - Indices that indicate equivalent
 #'     groups of SNPs.
-#' \item \code{intervals} - Indexes that indicate which marker
+#' * `intervals` - Indexes that indicate which marker
 #'     intervals the SNPs reside.
-#' \item \code{on_map} - Indicate whether SNP coincides with a marker
-#'     in the \code{genoprobs}
-#' }
+#' * `on_map` - Indicate whether SNP coincides with a marker
+#'     in the `genoprobs`
 #'
 #' @param show_all_snps If TRUE, expand to show all SNPs.
 #'
 #' @param add If TRUE, add to current plot (must have same map and
 #' chromosomes).
-#'
-#' @param cex Character expansion for the points (default 0.5)
-#'
-#' @param pch Plotting character for the points (default 16)
 #'
 #' @param drop.hilit SNPs with LOD score within this amount of the maximum SNP association will be highlighted.
 #'
@@ -43,13 +39,15 @@
 #'
 #' @param gap Gap between chromosomes.
 #'
-#' @param ylim y-axis limits
-#'
-#' @param bgcolor Background color for the plot.
-#'
-#' @param altbgcolor Background color for alternate chromosomes.
-#'
 #' @param ... Additional graphics parameters.
+#'
+#' @section Hidden graphics parameters:
+#' A number of graphics parameters can be passed via `...`. For
+#' example, `bgcolor` to control the background color and `altbgcolor`
+#' to control the background color on alternate chromosomes.
+#' `cex` for character expansion for the points (default 0.5),
+#' `pch` for the plotting character for the points (default 16),
+#' and `ylim` for y-axis limits.
 #'
 #' @examples
 #' \dontrun{
@@ -101,14 +99,13 @@
 #' plot(out_snps, snpinfo, drop.hilit=1.5)
 #' }
 #'
-#' @seealso \code{\link{plot_scan1}}, \code{\link{plot_coef}}, \code{\link{plot_coefCC}}
+#' @seealso [plot_scan1()], [plot_coef()], [plot_coefCC()]
 #' @export
 #'
 plot_snpasso <-
-    function(scan1output, snpinfo, show_all_snps=TRUE, drop.hilit=NA,
-             col.hilit="violetred", col="darkslateblue",
-             pch=16, cex=0.5, ylim=NULL, add=FALSE, gap=25,
-             bgcolor="gray90", altbgcolor="gray85", ...)
+    function(scan1output, snpinfo, show_all_snps=TRUE, add=FALSE,
+             drop.hilit=NA, col.hilit="violetred", col="darkslateblue",
+             gap=25, ...)
 {
     uindex <- unique(snpinfo$index)
     if(length(uindex) != nrow(scan1output))
@@ -138,8 +135,16 @@ plot_snpasso <-
     if(!is.na(drop.hilit) && !is.null(drop.hilit))
         col <- c(col, col.hilit)[(scan1output >= maxlod-drop.hilit)+1]
 
-    plot_scan1(scan1output, map, lodcolumn=1, bgcolor=bgcolor, altbgcolor=altbgcolor, ylim=ylim,
-               gap=gap, add=add, col = col, type="p", cex=cex, pch=pch, ...)
+    # internal function to give defaults to hidden graphics parameters
+    plot_snpasso_internal <-
+        function(pch=16, cex=0.5, ylim=NULL, bgcolor="gray90",
+                 altbgcolor="gray85", ...)
+    {
+        plot_scan1(scan1output, map, lodcolumn=1, bgcolor=bgcolor, altbgcolor=altbgcolor, ylim=ylim,
+                   gap=gap, add=add, col = col, type="p", cex=cex, pch=pch, ...)
+    }
+
+    plot_snpasso_internal(...)
 }
 
 

--- a/R/qtl2plot-package.R
+++ b/R/qtl2plot-package.R
@@ -2,12 +2,12 @@
 #' @importFrom Rcpp sourceCpp
 #' @useDynLib qtl2plot, .registration=TRUE
 #'
+#' @md
+#'
 #' @section Vignettes:
-#' \itemize{
-#' \item \href{http://kbroman.org/qtl2/assets/vignettes/user_guide.html}{user guide}
-#' \item \href{http://kbroman.org/qtl2/assets/vignettes/input_files.html}{input file formats}
-#' \item \href{http://kbroman.org/qtl2/pages/prep_do_data.html}{preparing DO mouse data for R/qtl2}
-#' \item \href{http://kbroman.org/qtl2/assets/vignettes/rqtl_diff.html}{differences between R/qtl and R/qtl2}
-#' \item \href{http://kbroman.org/qtl2/assets/vignettes/developer_guide.html}{developer guide}
-#' }
+#' * [user guide](http://kbroman.org/qtl2/assets/vignettes/user_guide.html)
+#' * [input file formats](http://kbroman.org/qtl2/assets/vignettes/input_files.html)
+#' * [preparing DO mouse data for R/qtl2](http://kbroman.org/qtl2/pages/prep_do_data.html)
+#' * [differences between R/qtl and R/qtl2](http://kbroman.org/qtl2/assets/vignettes/rqtl_diff.html)
+#' * [developer guide](http://kbroman.org/qtl2/assets/vignettes/developer_guide.html)
 "_PACKAGE"

--- a/R/xpos_scan1.R
+++ b/R/xpos_scan1.R
@@ -1,21 +1,21 @@
 #' Get x-axis position for genomic location
 #'
-#' For a plot of \code{\link[qtl2scan]{scan1}} results, get the x-axis
+#' For a plot of [qtl2scan::scan1()] results, get the x-axis
 #' location that corresponds to a particular genomic location
 #' (chromosome ID and position).
 #'
 #' @param map A list of vectors of marker positions, as produced by
-#' \code{\link[qtl2geno]{insert_pseudomarkers}}.
+#' [qtl2geno::insert_pseudomarkers()].
 #' @param chr Selected chromosomes that were plotted (if used in the
-#' call to \code{\link{plot_scan1}}).
+#' call to [plot_scan1()].
 #' @param gap The gap between chromosomes used in the call to
-#' \code{\link{plot_scan1}}.
+#' [plot_scan1()].
 #' @param thechr Vector of chromosome IDs
 #' @param thepos Vector of chromosomal positions
 #'
 #' @return A vector of x-axis locations.
 #'
-#' @details \code{thechr} and \code{thepos} should be the same length,
+#' @details `thechr` and `thepos` should be the same length,
 #' or should have length 1 (in which case they are expanded to the
 #' length of the other vector).
 #'

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -38,7 +38,7 @@ chromosomes).}
 
 \item{gap}{Gap between chromosomes.}
 
-\item{top_panel_prop}{If `scan1_output` provided, this gives the
+\item{top_panel_prop}{If \code{scan1_output} provided, this gives the
 proportion of the plot that is devoted to the top panel.}
 
 \item{...}{Additional graphics parameters.}

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -7,8 +7,7 @@
 \title{Plot QTL effects along chromosome}
 \usage{
 plot_coef(x, map, columns = NULL, col = NULL, scan1_output = NULL,
-  add = FALSE, gap = 25, ylim = NULL, bgcolor = "gray90",
-  altbgcolor = "gray85", ylab = "QTL effects", top_panel_prop = 0.65, ...)
+  add = FALSE, gap = 25, top_panel_prop = 0.65, ...)
 
 plot_coefCC(x, map, scan1_output = NULL, add = FALSE, gap = 25,
   ylim = NULL, bgcolor = "gray90", altbgcolor = "gray85",
@@ -39,15 +38,6 @@ chromosomes).}
 
 \item{gap}{Gap between chromosomes.}
 
-\item{ylim}{y-axis limits. If NULL, we use the range of the plotted
-coefficients.}
-
-\item{bgcolor}{Background color for the plot.}
-
-\item{altbgcolor}{Background color for alternate chromosomes.}
-
-\item{ylab}{y-axis label}
-
 \item{top_panel_prop}{If `scan1_output` provided, this gives the
 proportion of the plot that is devoted to the top panel.}
 
@@ -61,6 +51,19 @@ Plot estimated QTL effects along a chromosomes.
 \code{columns=1:8} and using the Collaborative Cross colors,
 \code{\link{CCcolors}}.
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color, and things
+like \code{ylab} and \code{ylim}. These are not included as formal
+parameters in order to avoid cluttering the function definition.
+
+In the case that \code{scan1_output} is provided, \code{col},
+\code{ylab}, and \code{ylim} all control the panel with estimated
+QTL effects, while \code{col_lod}, \code{ylab_lod}, and
+\code{ylim_lod} control the LOD curve panel.
+}
+
 \examples{
 # load qtl2geno package for data and genoprob calculation
 library(qtl2geno)

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -9,13 +9,10 @@
 plot_coef(x, map, columns = NULL, col = NULL, scan1_output = NULL,
   add = FALSE, gap = 25, top_panel_prop = 0.65, ...)
 
-plot_coefCC(x, map, scan1_output = NULL, add = FALSE, gap = 25,
-  ylim = NULL, bgcolor = "gray90", altbgcolor = "gray85",
-  ylab = "QTL effects", ...)
+plot_coefCC(x, map, scan1_output = NULL, add = FALSE, gap = 25, ...)
 
 \method{plot}{scan1coef}(x, map, columns = 1, col = NULL,
-  scan1_output = NULL, add = FALSE, gap = 25, ylim = NULL,
-  bgcolor = "gray90", altbgcolor = "gray85", ylab = "QTL effects", ...)
+  scan1_output = NULL, add = FALSE, gap = 25, ...)
 }
 \arguments{
 \item{x}{Estimated QTL effects ("coefficients") as obtained from

--- a/man/plot_coef.Rd
+++ b/man/plot_coef.Rd
@@ -19,10 +19,10 @@ plot_coefCC(x, map, scan1_output = NULL, add = FALSE, gap = 25,
 }
 \arguments{
 \item{x}{Estimated QTL effects ("coefficients") as obtained from
-\code{\link[qtl2scan]{scan1coef}}.}
+\code{\link[qtl2scan:scan1coef]{qtl2scan::scan1coef()}}.}
 
 \item{map}{A list of vectors of marker positions, as produced by
-\code{\link[qtl2geno]{insert_pseudomarkers}}.}
+\code{\link[qtl2geno:insert_pseudomarkers]{qtl2geno::insert_pseudomarkers()}}.}
 
 \item{columns}{Vector of columns to plot}
 
@@ -49,7 +49,7 @@ Plot estimated QTL effects along a chromosomes.
 \details{
 \code{plot_coefCC()} is the same as \code{plot_coef()}, but forcing
 \code{columns=1:8} and using the Collaborative Cross colors,
-\code{\link{CCcolors}}.
+\link{CCcolors}.
 }
 \section{Hidden graphics parameters}{
 
@@ -90,5 +90,5 @@ coef <- scan1coef(probs[,7], pheno, addcovar=covar)
 plot(coef, map[7], columns=1:3, col=c("slateblue", "violetred", "green3"))
 }
 \seealso{
-\code{\link{CCcolors}}, \code{\link{plot_scan1}}, \code{\link{plot_snpasso}}
+\link{CCcolors}, \code{\link[=plot_scan1]{plot_scan1()}}, \code{\link[=plot_snpasso]{plot_snpasso()}}
 }

--- a/man/plot_genes.Rd
+++ b/man/plot_genes.Rd
@@ -29,7 +29,7 @@ bp, \code{strand} (as \code{"-"}, \code{"+"}, or \code{NA}), and
 
 \item{name_field}{Character string with name of column containing the genes' names.}
 
-\item{...}{Optional arguments passed to \code{\link[graphics]{plot}}.}
+\item{...}{Optional arguments passed to \code{\link[graphics:plot]{graphics::plot()}}.}
 }
 \value{
 None.

--- a/man/plot_genes.Rd
+++ b/man/plot_genes.Rd
@@ -4,17 +4,14 @@
 \alias{plot_genes}
 \title{Plot gene locations for a genomic interval}
 \usage{
-plot_genes(genes, xlim = NULL, minrow = 4, padding = 0.2,
-  colors = c("black", "red3", "green4", "blue3", "orange"),
-  scale_pos = 0.000001, start_field = "start", stop_field = "stop",
-  strand_field = "strand", name_field = "Name", ...)
+plot_genes(genes, minrow = 4, padding = 0.2, colors = c("black", "red3",
+  "green4", "blue3", "orange"), scale_pos = 0.000001, start_field = "start",
+  stop_field = "stop", strand_field = "strand", name_field = "Name", ...)
 }
 \arguments{
 \item{genes}{Data frame containing \code{start} and \code{stop} in
 bp, \code{strand} (as \code{"-"}, \code{"+"}, or \code{NA}), and
 \code{Name}.}
-
-\item{xlim}{x-axis limits (in Mbp)}
 
 \item{minrow}{Minimum number of rows of genes in the plot}
 
@@ -41,6 +38,13 @@ None.
 Plot gene locations for a genomic interval, as rectangles with gene
 symbol (and arrow indicating strand/direction) below.
 }
+\section{Hidden graphics parameters}{
+
+Graphics parameters can be passed via \code{...}. For
+example, \code{xlim} to control the x-axis limits.
+These are not included as formal
+}
+
 \examples{
 genes <- data.frame(chr = c("6", "6", "6", "6", "6", "6", "6", "6"),
                     start = c(139988753, 140680185, 141708118, 142234227, 142587862,

--- a/man/plot_genoprob.Rd
+++ b/man/plot_genoprob.Rd
@@ -6,13 +6,11 @@
 \usage{
 plot_genoprob(probs, map, ind = 1, chr = NULL, geno = NULL,
   color_scheme = c("gray", "viridis"), col = NULL, threshold = 0,
-  swap_axes = FALSE, hlines = NULL, hlines_col = "#B3B3B370",
-  hlines_lwd = 1, hlines_lty = 1, vlines = NULL,
-  vlines_col = "#B3B3B370", vlines_lwd = 1, vlines_lty = 1, ...)
+  swap_axes = FALSE, ...)
 }
 \arguments{
-\item{probs}{Genotype probabilities (as produced by \code{\link[qtl2geno]{calc_genoprob}})
-or allele dosages (as produced by \code{\link[qtl2geno]{genoprob_to_alleleprob}}).}
+\item{probs}{Genotype probabilities (as produced by \code{\link[qtl2geno:calc_genoprob]{qtl2geno::calc_genoprob()}})
+or allele dosages (as produced by qtl2geno::genoprob_to_alleleprob()]).}
 
 \item{map}{Marker map (a list of vectors of marker positions).}
 
@@ -33,27 +31,23 @@ this value somewhere on the chromosome will be shown.}
 \item{swap_axes}{If TRUE, swap the axes, so that the genotypes are
 on the x-axis and the chromosome position is on the y-axis.}
 
-\item{hlines}{Position of horizontal grid lines (use \code{NA} to avoid lines).}
-
-\item{hlines_col}{Color of horizontal grid lines.}
-
-\item{hlines_lwd}{Line width of horizontal grid lines.}
-
-\item{hlines_lty}{Line type of horizontal grid lines.}
-
-\item{vlines}{Position of vertical grid lines (use \code{NA} to avoid lines).}
-
-\item{vlines_col}{Color of vertical grid lines.}
-
-\item{vlines_lwd}{Line width of vertical grid lines.}
-
-\item{vlines_lty}{Line type of vertical grid lines.}
-
-\item{...}{Additional graphics parameters passed to \code{\link[graphics]{image}}.}
+\item{...}{Additional graphics parameters passed to \code{\link[graphics:image]{graphics::image()}}.}
 }
 \description{
 Plot the genotype probabilities for one individual on one chromosome, as a heat map.
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{hlines}, \code{hlines_col}, \code{hlines_lwd}, and \code{hlines_lty} to
+control the horizontal grid lines. (Use \code{hlines=NA} to avoid
+plotting horizontal grid lines.) Similarly \code{vlines}, \code{vlines_col},
+\code{vlines_lwd}, and \code{vlines_lty} for vertical grid lines. You can
+also use many standard graphics parameters like \code{xlab} and \code{xlim}.
+These are not included as formal parameters in order to avoid
+cluttering the function definition.
+}
+
 \examples{
 # load data and calculate genotype probabilities
 library(qtl2geno)

--- a/man/plot_genoprob.Rd
+++ b/man/plot_genoprob.Rd
@@ -99,3 +99,6 @@ plot_genoprob(apr, DOex$pmap, ind="232")
 }
 
 }
+\seealso{
+\code{\link[=plot_genoprobcomp]{plot_genoprobcomp()}}
+}

--- a/man/plot_genoprobcomp.Rd
+++ b/man/plot_genoprobcomp.Rd
@@ -59,3 +59,6 @@ plot_genoprob(pr_ne, map, main="Assume very low error error")
 plot_genoprobcomp(pr_e, pr_ne, map, main="Comparison")
 
 }
+\seealso{
+\code{\link[=plot_genoprob]{plot_genoprob()}}
+}

--- a/man/plot_genoprobcomp.Rd
+++ b/man/plot_genoprobcomp.Rd
@@ -5,14 +5,11 @@
 \title{Plot comparison of two sets of genotype probabilities}
 \usage{
 plot_genoprobcomp(probs1, probs2, map, ind = 1, chr = NULL, geno = NULL,
-  threshold = 0, n_colors = 256, swap_axes = FALSE, hlines = NULL,
-  hlines_col = "#B3B3B370", hlines_lwd = 1, hlines_lty = 1,
-  vlines = NULL, vlines_col = "#B3B3B370", vlines_lwd = 1,
-  vlines_lty = 1, ...)
+  threshold = 0, n_colors = 256, swap_axes = FALSE, ...)
 }
 \arguments{
-\item{probs1}{Genotype probabilities (as produced by \code{\link[qtl2geno]{calc_genoprob}})
-or allele dosages (as produced by \code{\link[qtl2geno]{genoprob_to_alleleprob}}).}
+\item{probs1}{Genotype probabilities (as produced by \code{\link[qtl2geno:calc_genoprob]{qtl2geno::calc_genoprob()}})
+or allele dosages (as produced by \code{\link[qtl2geno:genoprob_to_alleleprob]{qtl2geno::genoprob_to_alleleprob()}}).}
 
 \item{probs2}{A second set of genotype probabilities, just like \code{probs1}.}
 
@@ -33,23 +30,7 @@ this value somewhere on the chromosome (in one or the other set of probabilities
 \item{swap_axes}{If TRUE, swap the axes, so that the genotypes are
 on the x-axis and the chromosome position is on the y-axis.}
 
-\item{hlines}{Position of horizontal grid lines (use \code{NA} to avoid lines).}
-
-\item{hlines_col}{Color of horizontal grid lines.}
-
-\item{hlines_lwd}{Line width of horizontal grid lines.}
-
-\item{hlines_lty}{Line type of horizontal grid lines.}
-
-\item{vlines}{Position of vertical grid lines (use \code{NA} to avoid lines).}
-
-\item{vlines_col}{Color of vertical grid lines.}
-
-\item{vlines_lwd}{Line width of vertical grid lines.}
-
-\item{vlines_lty}{Line type of vertical grid lines.}
-
-\item{...}{Additional graphics parameters passed to \code{\link[graphics]{image}}.}
+\item{...}{Additional graphics parameters passed to \code{\link[graphics:image]{graphics::image()}}.}
 }
 \description{
 Plot a comparison of two sets of genotype probabilities for one individual on one chromosome, as a heat map.

--- a/man/plot_onegeno.Rd
+++ b/man/plot_onegeno.Rd
@@ -6,12 +6,12 @@
 \usage{
 plot_onegeno(geno, map, ind = 1, chr = NULL, col = NULL,
   na_col = "white", swap_axes = FALSE, border = "black", shift = FALSE,
-  bgcolor = "gray90", chrwidth = 0.5, ...)
+  chrwidth = 0.5, ...)
 }
 \arguments{
 \item{geno}{Imputed phase-known genotypes, as a list of matrices
-(as produced by \code{\link[qtl2geno]{maxmarg}}) or a list of
-three-dimensional arrays (as produced by \code{\link[qtl2geno]{guess_phase}}).}
+(as produced by \code{\link[qtl2geno:maxmarg]{qtl2geno::maxmarg()}}) or a list of
+three-dimensional arrays (as produced by \code{\link[qtl2geno:guess_phase]{qtl2geno::guess_phase()}}).}
 
 \item{map}{Marker map (a list of vectors of marker positions).}
 
@@ -29,8 +29,6 @@ three-dimensional arrays (as produced by \code{\link[qtl2geno]{guess_phase}}).}
 
 \item{shift}{If TRUE, shift the chromosomes so they all start at 0.}
 
-\item{bgcolor}{Color for background rectangle}
-
 \item{chrwidth}{Total width of rectangles for each chromosome, as a
 fraction of the distance between them.}
 
@@ -39,6 +37,14 @@ fraction of the distance between them.}
 \description{
 Plot one individual's genome-wide genotypes
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color.
+These are not included as formal parameters in order to avoid
+cluttering the function definition.
+}
+
 \examples{
 # load data and calculate genotype probabilities
 library(qtl2geno)

--- a/man/plot_peaks.Rd
+++ b/man/plot_peaks.Rd
@@ -4,12 +4,11 @@
 \alias{plot_peaks}
 \title{Plot QTL peak locations}
 \usage{
-plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = 25,
-  bgcolor = "gray90", altbgcolor = "gray85", ...)
+plot_peaks(peaks, map, chr = NULL, tick_height = 0.3, gap = 25, ...)
 }
 \arguments{
 \item{peaks}{Data frame such as that produced by
-\code{\link[qtl2scan]{find_peaks}}) containing columns
+\code{\link[qtl2scan:find_peaks]{qtl2scan::find_peaks()}}) containing columns
 \code{chr}, \code{pos}, \code{lodindex}, and \code{lodcolumn}.
 May also contain columns \code{ci_lo} and \code{ci_hi}, in
 which case intervals will be plotted.}
@@ -24,10 +23,6 @@ strings.}
 
 \item{gap}{Gap between chromosomes.}
 
-\item{bgcolor}{Background color for the plot.}
-
-\item{altbgcolor}{Background color for alternate chromosomes.}
-
 \item{...}{Additional graphics parameters}
 }
 \value{
@@ -36,6 +31,15 @@ None.
 \description{
 Plot QTL peak locations (possibly with intervals) for multiple traits.
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color and
+\code{altbgcolor} to control the background color on alternate chromosomes.
+These are not included as formal parameters in order to avoid
+cluttering the function definition.
+}
+
 \examples{
 # load qtl2geno package for data and genoprob calculation
 library(qtl2geno)
@@ -65,5 +69,5 @@ peaks <- find_peaks(out, map, threshold=3.5, drop=1.5)
 plot_peaks(peaks, map)
 }
 \seealso{
-\code{\link[qtl2scan]{find_peaks}}
+\code{\link[qtl2scan:find_peaks]{qtl2scan::find_peaks()}}
 }

--- a/man/plot_pxg.Rd
+++ b/man/plot_pxg.Rd
@@ -5,15 +5,12 @@
 \title{Plot phenotype vs genotype}
 \usage{
 plot_pxg(geno, pheno, sort = TRUE, SEmult = NULL, pooledSD = TRUE,
-  swap_axes = FALSE, jitter = 0.2, bgcolor = "gray90", seg_width = NULL,
-  seg_lwd = 2, seg_col = "black", hlines = NULL, hlines_col = NULL,
-  hlines_lty = NULL, hlines_lwd = NULL, vlines = NULL,
-  vlines_col = NULL, vlines_lty = NULL, vlines_lwd = NULL,
-  force_labels = TRUE, alternate_labels = FALSE, omit_points = FALSE, ...)
+  swap_axes = FALSE, jitter = 0.2, force_labels = TRUE,
+  alternate_labels = FALSE, omit_points = FALSE, ...)
 }
 \arguments{
 \item{geno}{Vector of genotypes, as produced by
-\code{\link[qtl2geno]{maxmarg}} with specific \code{chr} and
+\code{\link[qtl2geno:maxmarg]{qtl2geno::maxmarg()}} with specific \code{chr} and
 \code{pos}.}
 
 \item{pheno}{Vector of phenotypes.}
@@ -34,41 +31,30 @@ on the y-axis and the phenotype is on the x-axis.}
 of length > 0, it is taken to be the actual jitter amounts
 (with values between -0.5 and 0.5).}
 
-\item{bgcolor}{Background color for the plot.}
-
-\item{seg_width}{Width of segments at the estimated within-group averages}
-
-\item{seg_lwd}{Line width used to plot estimated within-group averages}
-
-\item{seg_col}{Line color used to plot estimated within-group averages}
-
-\item{hlines}{Locations of horizontal grid lines.}
-
-\item{hlines_col}{Color of horizontal grid lines}
-
-\item{hlines_lty}{Line type of horizontal grid lines}
-
-\item{hlines_lwd}{Line width of horizontal grid lines}
-
-\item{vlines}{Locations of vertical grid lines.}
-
-\item{vlines_col}{Color of vertical grid lines}
-
-\item{vlines_lty}{Line type of vertical grid lines}
-
-\item{vlines_lwd}{Line width of vertical grid lines}
-
 \item{force_labels}{If TRUE, force all genotype labels to be shown.}
 
 \item{alternate_labels}{If TRUE, place genotype labels in two rows}
 
 \item{omit_points}{If TRUE, omit the points, just plotting the averages (and, potentially, the +/- SE intervals).}
 
-\item{...}{Additional graphics parameters, passed to \code{\link[graphics]{plot}}.}
+\item{...}{Additional graphics parameters, passed to \code{\link[graphics:plot]{graphics::plot()}}.}
 }
 \description{
 Plot phenotype vs genotype for a single putative QTL and a single phenotype.
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color, and
+\code{seg_width}, \code{seg_lwd}, and \code{seg_col} to control the lines at the
+confidence intervals. Further, \code{hlines}, \code{hlines_col},
+\code{hlines_lwd}, and \code{hlines_lty} to control the horizontal grid
+lines. (Use \code{hlines=NA} to avoid plotting horizontal grid lines.)
+Similarly \code{vlines}, \code{vlines_col}, \code{vlines_lwd}, and \code{vlines_lty}
+for vertical grid lines. These are not included as formal
+parameters in order to avoid cluttering the function definition.
+}
+
 \examples{
 # load qtl2geno package for data and genoprob calculation
 library(qtl2geno)
@@ -101,5 +87,5 @@ plot_pxg(geno, log10(iron$pheno[,1]), ylab=expression(log[10](Liver)),
          omit_points=TRUE, SEmult=2)
 }
 \seealso{
-\code{\link{plot_coef}}
+\code{\link[=plot_coef]{plot_coef()}}
 }

--- a/man/plot_scan1.Rd
+++ b/man/plot_scan1.Rd
@@ -6,16 +6,16 @@
 \title{Plot a genome scan}
 \usage{
 plot_scan1(x, map, lodcolumn = 1, chr = NULL, add = FALSE, gap = 25,
-  bgcolor = "gray90", altbgcolor = "gray85", ...)
+  ...)
 
 \method{plot}{scan1}(x, map, lodcolumn = 1, chr = NULL, add = FALSE,
-  gap = 25, bgcolor = "gray90", altbgcolor = "gray85", ...)
+  gap = 25, ...)
 }
 \arguments{
-\item{x}{Output of \code{\link[qtl2scan]{scan1}}.}
+\item{x}{Output of \code{\link[qtl2scan:scan1]{qtl2scan::scan1()}}.}
 
 \item{map}{A list of vectors of marker positions, as produced by
-\code{\link[qtl2geno]{insert_pseudomarkers}}.}
+\code{\link[qtl2geno:insert_pseudomarkers]{qtl2geno::insert_pseudomarkers()}}.}
 
 \item{lodcolumn}{LOD score column to plot (a numeric index, or a
 character string for a column name). Only one value allowed.}
@@ -28,10 +28,6 @@ chromosomes).}
 
 \item{gap}{Gap between chromosomes.}
 
-\item{bgcolor}{Background color for the plot.}
-
-\item{altbgcolor}{Background color for alternate chromosomes.}
-
 \item{...}{Additional graphics parameters.}
 }
 \value{
@@ -40,6 +36,15 @@ None.
 \description{
 Plot LOD curves for a genome scan
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color and
+\code{altbgcolor} to control the background color on alternate chromosomes.
+These are not included as formal parameters in order to avoid
+cluttering the function definition.
+}
+
 \examples{
 # load qtl2geno package for data and genoprob calculation
 library(qtl2geno)
@@ -80,5 +85,5 @@ plot(out, map, lodcolumn="liver", ylim=ylim)
 plot(out, map, lodcolumn="spleen", col="violetred", add=TRUE)
 }
 \seealso{
-\code{\link{plot_coef}}, \code{\link{plot_coefCC}}, \code{\link{plot_snpasso}}
+\code{\link[=plot_coef]{plot_coef()}}, \code{\link[=plot_coefCC]{plot_coefCC()}}, \code{\link[=plot_snpasso]{plot_snpasso()}}
 }

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -98,7 +98,6 @@ snp_pr <- genoprob_to_snpprob(apr, snpinfo)
 out_snps <- scan1(snp_pr, DOex$pheno)
 
 # plot results
-library(qtl2plot)
 plot_snpasso(out_snps, snpinfo)
 
 # can also just type plot()

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -4,37 +4,39 @@
 \alias{plot_snpasso}
 \title{Plot SNP associations}
 \usage{
-plot_snpasso(scan1output, snpinfo, show_all_snps = TRUE, drop.hilit = NA,
-  col.hilit = "violetred", col = "darkslateblue", pch = 16, cex = 0.5,
-  ylim = NULL, add = FALSE, gap = 25, bgcolor = "gray90",
-  altbgcolor = "gray85", ...)
+plot_snpasso(scan1output, snpinfo, show_all_snps = TRUE, add = FALSE,
+  drop.hilit = NA, col.hilit = "violetred", col = "darkslateblue",
+  gap = 25, ...)
 }
 \arguments{
-\item{scan1output}{Output of \code{\link[qtl2scan]{scan1}} using
+\item{scan1output}{Output of \code{\link[qtl2scan:scan1]{qtl2scan::scan1()}} using
 SNP probabilities derived by
-\code{\link[qtl2scan]{genoprob_to_snpprob}}.}
+\code{\link[qtl2scan:genoprob_to_snpprob]{qtl2scan::genoprob_to_snpprob()}}.}
 
 \item{snpinfo}{Data frame with SNP information with the following
-    columns (the last three are generally derived from with
-    \code{\link[qtl2scan]{index_snps}}):
+columns (the last three are generally derived from with
+\code{\link[qtl2scan:index_snps]{qtl2scan::index_snps()}}):
 \itemize{
 \item \code{chr} - Character string or factor with chromosome
 \item \code{pos} - Position (in same units as in the \code{"map"}
-    attribute in \code{genoprobs}.
+attribute in \code{genoprobs}.
 \item \code{sdp} - Strain distribution pattern: an integer, between
-    1 and \eqn{2^n - 2} where \eqn{n} is the number of strains, whose
-    binary encoding indicates the founder genotypes
+1 and \eqn{2^n - 2} where \eqn{n} is the number of strains, whose
+binary encoding indicates the founder genotypes
 \item \code{snp} - Character string with SNP identifier (if
-    missing, the rownames are used).
+missing, the rownames are used).
 \item \code{index} - Indices that indicate equivalent
-    groups of SNPs.
+groups of SNPs.
 \item \code{intervals} - Indexes that indicate which marker
-    intervals the SNPs reside.
+intervals the SNPs reside.
 \item \code{on_map} - Indicate whether SNP coincides with a marker
-    in the \code{genoprobs}
+in the \code{genoprobs}
 }}
 
 \item{show_all_snps}{If TRUE, expand to show all SNPs.}
+
+\item{add}{If TRUE, add to current plot (must have same map and
+chromosomes).}
 
 \item{drop.hilit}{SNPs with LOD score within this amount of the maximum SNP association will be highlighted.}
 
@@ -42,26 +44,23 @@ SNP probabilities derived by
 
 \item{col}{Color of other points}
 
-\item{pch}{Plotting character for the points (default 16)}
-
-\item{cex}{Character expansion for the points (default 0.5)}
-
-\item{ylim}{y-axis limits}
-
-\item{add}{If TRUE, add to current plot (must have same map and
-chromosomes).}
-
 \item{gap}{Gap between chromosomes.}
-
-\item{bgcolor}{Background color for the plot.}
-
-\item{altbgcolor}{Background color for alternate chromosomes.}
 
 \item{...}{Additional graphics parameters.}
 }
 \description{
 Plot SNP associations, with possible expansion from distinct snps to all snps.
 }
+\section{Hidden graphics parameters}{
+
+A number of graphics parameters can be passed via \code{...}. For
+example, \code{bgcolor} to control the background color and \code{altbgcolor}
+to control the background color on alternate chromosomes.
+\code{cex} for character expansion for the points (default 0.5),
+\code{pch} for the plotting character for the points (default 16),
+and \code{ylim} for y-axis limits.
+}
+
 \examples{
 \dontrun{
 # load example DO data from web
@@ -114,5 +113,5 @@ plot(out_snps, snpinfo, drop.hilit=1.5)
 
 }
 \seealso{
-\code{\link{plot_scan1}}, \code{\link{plot_coef}}, \code{\link{plot_coefCC}}
+\code{\link[=plot_scan1]{plot_scan1()}}, \code{\link[=plot_coef]{plot_coef()}}, \code{\link[=plot_coefCC]{plot_coefCC()}}
 }

--- a/man/plot_snpasso.Rd
+++ b/man/plot_snpasso.Rd
@@ -5,7 +5,7 @@
 \title{Plot SNP associations}
 \usage{
 plot_snpasso(scan1output, snpinfo, show_all_snps = TRUE, add = FALSE,
-  drop.hilit = NA, col.hilit = "violetred", col = "darkslateblue",
+  drop_hilit = NA, col_hilit = "violetred", col = "darkslateblue",
   gap = 25, ...)
 }
 \arguments{
@@ -38,9 +38,9 @@ in the \code{genoprobs}
 \item{add}{If TRUE, add to current plot (must have same map and
 chromosomes).}
 
-\item{drop.hilit}{SNPs with LOD score within this amount of the maximum SNP association will be highlighted.}
+\item{drop_hilit}{SNPs with LOD score within this amount of the maximum SNP association will be highlighted.}
 
-\item{col.hilit}{Color of highlighted points}
+\item{col_hilit}{Color of highlighted points}
 
 \item{col}{Color of other points}
 
@@ -108,7 +108,7 @@ plot(out_snps, snpinfo)
 plot_snpasso(out_snps, snpinfo, show_all_snps=FALSE)
 
 # highlight the top snps (with LOD within 1.5 of max)
-plot(out_snps, snpinfo, drop.hilit=1.5)
+plot(out_snps, snpinfo, drop_hilit=1.5)
 }
 
 }

--- a/man/xpos_scan1.Rd
+++ b/man/xpos_scan1.Rd
@@ -8,13 +8,13 @@ xpos_scan1(map, chr = NULL, gap = 25, thechr, thepos)
 }
 \arguments{
 \item{map}{A list of vectors of marker positions, as produced by
-\code{\link[qtl2geno]{insert_pseudomarkers}}.}
+[qtl2geno::insert_pseudomarkers()].}
 
 \item{chr}{Selected chromosomes that were plotted (if used in the
-call to \code{\link{plot_scan1}}).}
+call to [plot_scan1()].}
 
 \item{gap}{The gap between chromosomes used in the call to
-\code{\link{plot_scan1}}.}
+[plot_scan1()].}
 
 \item{thechr}{Vector of chromosome IDs}
 
@@ -24,12 +24,12 @@ call to \code{\link{plot_scan1}}).}
 A vector of x-axis locations.
 }
 \description{
-For a plot of \code{\link[qtl2scan]{scan1}} results, get the x-axis
+For a plot of [qtl2scan::scan1()] results, get the x-axis
 location that corresponds to a particular genomic location
 (chromosome ID and position).
 }
 \details{
-\code{thechr} and \code{thepos} should be the same length,
+`thechr` and `thepos` should be the same length,
 or should have length 1 (in which case they are expanded to the
 length of the other vector).
 }


### PR DESCRIPTION
In many of the plot functions, hide various detailed graphics parameters, to be grabbed from the `...` argument, and add a section "Hidden graphics parameters" in the documentation.

Having of graphics parameters makes the function definitions intimidating, and most are seldom used (I think). Hiding them, though, makes it harder to figure out what parameters are available, what their names are, and what they do.

See Issue #38.